### PR TITLE
Support multiple testnet genesis.json files 

### DIFF
--- a/nodesuite_cli.py
+++ b/nodesuite_cli.py
@@ -544,7 +544,8 @@ def configureDefaultsAll(config_path, overwrite):
         'setup_oig: ',
         'nodeos_bin: nodeos',
         'cli_bin: cleos',
-        'keosd_bin: keosd'
+        'keosd_bin: keosd',
+        'testnet_name:'
     ]
 
     f.writelines(defaults)

--- a/roles/deploy_node/files/eos/test/jungle/genesis.json
+++ b/roles/deploy_node/files/eos/test/jungle/genesis.json
@@ -1,0 +1,24 @@
+{
+  "initial_timestamp": "2020-02-19T16:20:00",
+  "initial_key": "EOS6jUngLeXUEPEtS5A4JmEZUjg6ccuFAyshsg4Ty3MN6ks34quiX",
+  "initial_configuration": {
+    "max_block_net_usage": 524288,
+    "target_block_net_usage_pct": 1000,
+    "max_transaction_net_usage": 524287,
+    "base_per_transaction_net_usage": 12,
+    "net_usage_leeway": 500,
+    "context_free_discount_net_usage_num": 20,
+    "context_free_discount_net_usage_den": 100,
+    "max_block_cpu_usage": 400000,
+    "target_block_cpu_usage_pct": 10,
+    "max_transaction_cpu_usage": 150000,
+    "min_transaction_cpu_usage": 1,
+    "max_transaction_lifetime": 3600,
+    "deferred_trx_expiration_window": 600,
+    "max_transaction_delay": 3888000,
+    "max_inline_action_size": 524287,
+    "max_inline_action_depth": 32,
+    "max_authority_depth": 6,
+    "max_ram_size": 34359738368
+  }
+}

--- a/roles/deploy_node/files/eos/test/kylin/genesis.json
+++ b/roles/deploy_node/files/eos/test/kylin/genesis.json
@@ -1,0 +1,23 @@
+{
+  "initial_timestamp": "2018-07-11T05:30:00.000",
+  "initial_key": "EOS7hHHDtnPRbhMmfHJHUEKQyiutKrt9wZPdy1JbaATVLyxpCkrop",
+  "initial_configuration": {
+    "max_block_net_usage": 1048576,
+    "target_block_net_usage_pct": 1000,
+    "max_transaction_net_usage": 524288,
+    "base_per_transaction_net_usage": 12,
+    "net_usage_leeway": 500,
+    "context_free_discount_net_usage_num": 20,
+    "context_free_discount_net_usage_den": 100,
+    "max_block_cpu_usage": 200000,
+    "target_block_cpu_usage_pct": 1000,
+    "max_transaction_cpu_usage": 150000,
+    "min_transaction_cpu_usage": 100,
+    "max_transaction_lifetime": 3600,
+    "deferred_trx_expiration_window": 600,
+    "max_transaction_delay": 3888000,
+    "max_inline_action_size": 4096,
+    "max_inline_action_depth": 4,
+    "max_authority_depth": 6
+  }
+}

--- a/roles/deploy_node/tasks/genesis.yml
+++ b/roles/deploy_node/tasks/genesis.yml
@@ -3,3 +3,10 @@
   copy:
     src: '{{ name }}/{{ stage }}/genesis.json'
     dest: '{{ genesis_json_path }}'
+  when: testnet_name is not defined
+
+- name: Install {{ name }} {{ stage }} genesis.json - {{ testnet_name }}
+  copy:
+    src: '{{ name }}/{{ stage }}/{{ testnet_name }}/genesis.json'
+    dest: '{{ genesis_json_path }}'
+  when: testnet_name is defined


### PR DESCRIPTION
Support multiple testnet genesis.json files (i.e. configurations for both the jungle & kylin EOS testnets exist within the same stage).