### PR TITLE
Remove forking for nodeos start script

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -5,6 +5,7 @@ enable_plugins = yaml
 host_key_checking = False
 callback_whitelist = profile_tasks
 interpreter_python = auto
+allow_world_readable_tmpfiles=true
 
 [ssh_connection]
 ssh_args = -o ForwardAgent=yes -o ControlMaster=auto -o ControlPersist=60s

--- a/roles/deploy_node/templates/nodeos.service.j2
+++ b/roles/deploy_node/templates/nodeos.service.j2
@@ -5,7 +5,6 @@ After=network.target
 [Service]
 User={{ deploy_user }}
 Restart=always
-Type=forking
 WorkingDirectory={{ working_dir}}/deploy
 ExecStart={{ working_dir }}/deploy/start.sh
 

--- a/roles/deploy_node/templates/start.sh.j2
+++ b/roles/deploy_node/templates/start.sh.j2
@@ -16,4 +16,4 @@
 {% set disable_replay_opts_flag = '--disable-replay-opts' if (setup_state_history | d() | bool) else empty_flag %} 
 {% set account_queries_flag = '--enable-account-queries=true' if (enable_account_queries | d() | bool) else empty_flag %}
 
-{{ working_dir }}/deploy/nodeos --data-dir {{ working_dir }}/{{ data_dir }} --config-dir {{ working_dir }}/deploy {{ replay_flag }} {{ snapshot_flag }} {{ snapshot }} {{ genesis_json_flag }} {{ genesis_json }} {{ account_queries_flag }} {{ disable_replay_opts_flag }} &
+{{ working_dir }}/deploy/nodeos --data-dir {{ working_dir }}/{{ data_dir }} --config-dir {{ working_dir }}/deploy {{ replay_flag }} {{ snapshot_flag }} {{ snapshot }} {{ genesis_json_flag }} {{ genesis_json }} {{ account_queries_flag }} {{ disable_replay_opts_flag }}


### PR DESCRIPTION
While we were deploying new instances for the LACChain network we found that being able to inspect the logs from nodeos using standard Systemd commands like `journalctl` would be useful.
Also we needed to add a config to the `ansible.cfg` file to make it work in some of our deploying machines.

cc: @kuronosec