### PR TITLE
Leap 4.0.X

### DIFF
--- a/data/defaults
+++ b/data/defaults
@@ -140,8 +140,8 @@ all:
     bin_package: yes
     bin_src: remote
     bin_package_base_url: https://github.com/AntelopeIO/leap/releases/download
-    version: v3.2.3
-    package: leap_3.2.3-ubuntu20.04_amd64.deb
+    version: v4.0.1
+    package: leap_4.0.1-ubuntu20.04_amd64.deb
     build_script: pinned_build.sh
     apply_patch: ''
     force_build: ''

--- a/roles/build_source/tasks/prebuilt/bin.yml
+++ b/roles/build_source/tasks/prebuilt/bin.yml
@@ -5,11 +5,20 @@
 
 - name: Copying {{ package }} to host
   copy:
-    src: '{{ name }}/{{ package }}'
-    dest: '{{ working_dir }}/dist/{{ package }}'
-    owner: '{{ deploy_user }}'
-    group: '{{ deploy_group }}'
-  when: bin_src == 'local'
+    src: "{{ name }}/{{ package }}"
+    dest: "{{ working_dir }}/dist/{{ package }}"
+    owner: "{{ deploy_user }}"
+    group: "{{ deploy_group }}"
+  when: bin_src == 'local' and name not in ['eos', 'proton', 'telos', 'libre', 'ore']
+
+- name: Copying {{ package }} to host
+  copy:
+    src: "eos/{{ package }}"
+    dest: "{{ working_dir }}/dist/{{ package }}"
+    owner: "{{ deploy_user }}"
+    group: "{{ deploy_group }}"
+  when: bin_src == 'local' and name in ['eos', 'proton', 'telos', 'libre', 'ore']
+
 
 - name: Download {{ package }} to host
   get_url:
@@ -60,7 +69,6 @@
     - '{{ nodeos_bin }}'
     - '{{ cli_bin }}'
     - '{{ keosd_bin }}'
-    - '{{ blocklog_bin }}'
     - '{{ trace_api_bin }}'
 
 - name: Versioning utility tool binaries
@@ -74,5 +82,6 @@
   become: yes
   become_user: root
   loop:
+    - '{{ blocklog_bin }}'
     - '{{ leap_util_bin }}'
   ignore_errors: yes

--- a/roles/deploy_node/defaults/main.yml
+++ b/roles/deploy_node/defaults/main.yml
@@ -25,7 +25,6 @@ chain_threads: 2
 http_threads: 2
 net_threads: 2
 producer_threads: 2
-txn_test_gen_threads: 2
 sync_fetch_span: 500
 max_transaction_time: 150000
 claims_hour: '*'

--- a/roles/deploy_node/templates/config.ini.j2
+++ b/roles/deploy_node/templates/config.ini.j2
@@ -159,9 +159,6 @@ producer-threads = {{ producer_threads }}
 # the location of the snapshots directory (absolute path or relative to application data dir) (eosio::producer_plugin)
 # snapshots-dir = "snapshots"
 
-# Number of worker threads in txn_test_gen thread pool (eosio::txn_test_gen_plugin)
-txn-test-gen-threads = {{ txn_test_gen_threads }}
-
 # Plugin(s) to enable, may be specified multiple times
 # plugin =
 {% for plugin in plugins %}


### PR DESCRIPTION
- Compatible with leap 4.0
- Improved deployment of local packages: For chains that use vanilla leap, the package found in the eos files directory will now be used instead of requiring a package in each chain's files directory